### PR TITLE
Update and rename README to README.md

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,0 @@
-Pretend You're Xyzzy, a Cards Against Humanity clone, server and web client. See WebContent/license.html for full details.
-
-Note: This project has only been tested in Tomcat 7 and is known to not work in Tomcat 6 without some finagling. Currently, the only automated way to build is is using the Eclipse project.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+Pretend You're Xyzzy
+===================
+
+A Cards Against Humanity clone, server and web client. See WebContent/license.html for full details.
+
+Note: This project is only known to work with Tomcat 7, all other versions are unsupported. 
+Currently, the only way to build PYX is using Maven via ```mvn clean package war:war``` in the project's directory.


### PR DESCRIPTION
The README file needs an update. As Eclipse will no longer compile the WAR correctly. Using Maven will compile PYX correctly.